### PR TITLE
Refactor `Bucket.Write` and `Bucket.Read` methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `Bucket.list`,  [PR-42](https://github.com/reduct-storage/reduct-cpp/pull/42)
 
+
+### Changed
+
+- Refactor Bucket.Write and Bucket.Read methods, [PR-43](https://github.com/reduct-storage/reduct-cpp/pull/43)
+
 ## [0.8.0] - 2022-08-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -33,14 +33,14 @@ int main() {
 
   // Write some data
   IBucket::Time ts = IBucket::Time::clock::now();
-  [[maybe_unused]] auto write_err = bucket->Write("entry-1", "some_data1", ts);
+  [[maybe_unused]] auto write_err = bucket->Write("entry-1", ts, [](auto rec) { rec->WriteAll("some_data1"); });
 
   // Read data via timestamp
   auto [blob, read_err] = bucket->Read("entry-1", ts);
   if (!read_err) {
     std::cout << "Read blob: " <<  blob << std::endl;
   }
-  
+
   // Walk through the data
   err = bucket->Query("entry-1", std::nullopt, IBucket::Time::clock::now(), std::nullopt, [](auto&& record) {
     std::string blob;

--- a/docs/api_reference/ibucket.md
+++ b/docs/api_reference/ibucket.md
@@ -45,21 +45,23 @@ The interface provides method`IClient::Write` to write some data to an entry:
 
 ```cpp
 IBucket::Time ts = IBucket::Time::clock::now();
-[[maybe_unused]] auto write_err = bucket->Write("entry-1", "some_data1", ts);
+[[maybe_unused]] auto write_err = bucket->Write("entry-1", ts, [](auto rec) { rec->WriteAll("some_data1"); });
 ```
 
 You also can write a big blob by chunks:
 
 ```cpp
 const std::string blob(10'000, 'x');
-bucket->Write("entry", ts, blob.size(), [&blob](auto offset, auto size) {
-    return std::pair{true, blob.substr(offset, size)};
+bucket->Write("entry", ts, [](auto rec) {
+    rec->Write(blob.size(), [&blob](auto offset, auto size) {
+        return std::pair{true, blob.substr(offset, size)};
+    });
 });
 ```
 
 ### Query
 
-The `IClient::Quert` method allows to iterate records for a time interval:
+The `IClient::Query` method allows to iterate records for a time interval:
 
 ```cpp
   err = bucket->Query("entry-1", start, IBucket::Time::clock::now(), std::nullopt, [](auto&& record) {

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -8,7 +8,8 @@ Reduct Storage C++ SDK is written in C++20 and uses cmake as a build system. To 
 * cmake 3.18 or higher
 * conan 1.40 or higher (it is optional, but [**conan**](https://conan.io) is cool!)
 
-Currently, we test only Linux AMD64, but if you need to port it to another OS or platform, feel free to make an [issue](https://github.com/reduct-storage/reduct-cpp/issues/new/choose).
+Currently, we test only Linux AMD64, but if you need to port it to another OS or platform, feel free to make
+an [issue](https://github.com/reduct-storage/reduct-cpp/issues/new/choose).
 
 ## Installing
 
@@ -25,13 +26,15 @@ sudo cmake --build . --target install
 
 ## Simple Application
 
-Let's create a simple C++ application which connects to the storage, creates a bucket and writes/reads some data. We need two files:
+Let's create a simple C++ application which connects to the storage, creates a bucket and writes/reads some data. We
+need two files:
 
 ```
 touch CMakeLists.txt main.cc
 ```
 
-I'm sure you're familiar to cmake, so I don't have to explain all the detail. The `CMakeLists.txt` should look like this:
+I'm sure you're familiar to cmake, so I don't have to explain all the detail. The `CMakeLists.txt` should look like
+this:
 
 ```cmake
 cmake_minimum_required(VERSION 3.18)
@@ -71,7 +74,7 @@ int main() {
 
   // Write some data
   IBucket::Time ts = IBucket::Time::clock::now();
-  [[maybe_unused]] auto write_err = bucket->Write("entry-1", "some_data1", ts);
+  [[maybe_unused]] auto write_err = bucket->Write("entry-1", ts, [](auto rec) { rec->WriteAll("some_data1"); });
 
   // Read data
   auto [blob, read_err] = bucket->Read("entry-1", ts);
@@ -92,7 +95,7 @@ cmake --build .
 Let's run the code, but before you need to run the storage. For this, we have to run it as a Docker container:
 
 ```
-docker run -p 8383:8383  ghcr.io/reduct-storage/reduct-storage:main
+docker run -p 8383:8383  reductstorage/engine:latest
 ```
 
 Now you can launch the example:

--- a/examples/usage_example.cc
+++ b/examples/usage_example.cc
@@ -27,9 +27,9 @@ int main() {
 
   // Write some data
   IBucket::Time start = IBucket::Time::clock::now();
-  [[maybe_unused]] auto write_err = bucket->Write("entry-1", "some_data1");
-  write_err = bucket->Write("entry-1", "some_data2");
-  write_err = bucket->Write("entry-1", "some_data3");
+  [[maybe_unused]] auto write_err = bucket->Write("entry-1", {}, [](auto rec) { rec->WriteAll("some_data1"); });
+  write_err = bucket->Write("entry-1", {}, [](auto rec) { rec->WriteAll("some_data2"); });
+  write_err = bucket->Write("entry-1", {}, [](auto rec) { rec->WriteAll("some_data3"); });
 
   // Walk through the data
   err = bucket->Query("entry-1", start, IBucket::Time::clock::now(), std::nullopt, [](auto&& record) {

--- a/src/reduct/bucket.h
+++ b/src/reduct/bucket.h
@@ -97,7 +97,7 @@ class IBucket {
   /**
    * Callback to receive a record
    */
-  using RecordCallback = std::function<bool(ReadableRecord&& record)>;
+  using RecordCallback = std::function<bool(const ReadableRecord& record)>;
 
   /**
    * Write an object to the storage with timestamp

--- a/src/reduct/internal/http_client.cc
+++ b/src/reduct/internal/http_client.cc
@@ -49,7 +49,9 @@ class HttpClient : public IHttpClient {
             headers[lowcase_header] = v;
           }
 
-          resp_callback(std::move(headers));
+          if (!err) {
+            resp_callback(std::move(headers));
+          }
           return true;
         },
         [&](const char* data, size_t size) {

--- a/tests/fixture.h
+++ b/tests/fixture.h
@@ -29,14 +29,15 @@ struct Fixture {
     }
 
     bucket_1 = client->CreateBucket("bucket_1").result;
-    [[maybe_unused]] auto ret = bucket_1->Write("entry-1", "data-1", IBucket::Time() + s(1));
-    ret = bucket_1->Write("entry-1", "data-2", IBucket::Time() + s(2));
-    ret = bucket_1->Write("entry-2", "data-3", IBucket::Time() + s(3));
-    ret = bucket_1->Write("entry-2", "data-4", IBucket::Time() + s(4));
+    [[maybe_unused]] auto ret =
+        bucket_1->Write("entry-1", IBucket::Time() + s(1), [](auto rec) { rec->WriteAll("data-1"); });
+    ret = bucket_1->Write("entry-1", IBucket::Time() + s(2), [](auto rec) { rec->WriteAll("data-2"); });
+    ret = bucket_1->Write("entry-2", IBucket::Time() + s(3), [](auto rec) { rec->WriteAll("data-3"); });
+    ret = bucket_1->Write("entry-2", IBucket::Time() + s(4), [](auto rec) { rec->WriteAll("data-4"); });
 
     bucket_2 = client->CreateBucket("bucket_2").result;
-    ret = bucket_2->Write("entry-1", "data-5", IBucket::Time() + s(5));
-    ret = bucket_2->Write("entry-1", "data-6", IBucket::Time() + s(6));
+    ret = bucket_2->Write("entry-1", IBucket::Time() + s(5), [](auto rec) { rec->WriteAll("data-5"); });
+    ret = bucket_2->Write("entry-1", IBucket::Time() + s(6), [](auto rec) { rec->WriteAll("data-6"); });
   }
 
   std::unique_ptr<reduct::IClient> client;

--- a/tests/reduct/bucket_api_test.cc
+++ b/tests/reduct/bucket_api_test.cc
@@ -112,8 +112,9 @@ TEST_CASE("reduct::IBucket should get bucket stats", "[bucket_api]") {
   auto [bucket, _] = ctx.client->CreateBucket(kBucketName);
 
   auto t = IBucket::Time();
-  REQUIRE(bucket->Write("entry-1", "some_data", t) == Error::kOk);
-  REQUIRE(bucket->Write("entry-2", "some_data", t + std::chrono::seconds(1)) == Error::kOk);
+  REQUIRE(bucket->Write("entry-1", t, [](auto record) { record->WriteAll("some_data"); }) == Error::kOk);
+  REQUIRE(bucket->Write("entry-2", t + std::chrono::seconds(1), [](auto record) { record->WriteAll("some_data"); }) ==
+          Error::kOk);
 
   auto [info, err] = bucket->GetInfo();
   REQUIRE(err == Error::kOk);

--- a/tests/reduct/entry_api_test.cc
+++ b/tests/reduct/entry_api_test.cc
@@ -21,13 +21,13 @@ TEST_CASE("reduct::IBucket should write/read a record", "[entry_api]") {
   REQUIRE(err == Error::kOk);
   REQUIRE(bucket);
 
-  IBucket::Time ts = IBucket::Time::clock::now();
+  IBucket::Time ts = IBucket::Time() + std::chrono::microseconds(123109210);
   std::string_view blob("some blob of data");
   REQUIRE(bucket->Write("entry", blob, ts) == Error::kOk);
 
   std::string received_data;
   err = bucket->Read("entry", ts, [&received_data, ts](auto record) {
-    REQUIRE(record.size == 10);
+    REQUIRE(record.size == 17);
     REQUIRE(record.timestamp == ts);
     REQUIRE(record.last);
 
@@ -41,7 +41,7 @@ TEST_CASE("reduct::IBucket should write/read a record", "[entry_api]") {
   REQUIRE(received_data == blob);
 
   SECTION("http errors") {
-    REQUIRE(bucket->Read("entry", IBucket::Time(), [](auto) { return false; }) ==
+    REQUIRE(bucket->Read("entry", IBucket::Time(), [](auto) { return true; }) ==
             Error{.code = 404, .message = "No records for this timestamp"});
   }
 }


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Refactoring

### What is the current behavior?

See #41

### What is the new behavior?

Bucket.Write and Bucket.Read return proxy objects for IO operations.


### Does this PR introduce a breaking change?

Yes

### Other information:
