### PR TITLE
Fix sending data in chunks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Sending data in chunks, [PR-44](https://github.com/reduct-storage/reduct-cpp/pull/44)
+
 ## [1.0.0] - 2022-10-09
 
 ### Added

--- a/src/reduct/internal/http_client.cc
+++ b/src/reduct/internal/http_client.cc
@@ -13,6 +13,8 @@ namespace reduct::internal {
 
 using httplib::DataSink;
 
+constexpr size_t kMaxChunkSize = 1'000'000;
+
 class HttpClient : public IHttpClient {
  public:
   explicit HttpClient(std::string_view url, const HttpOptions& options)
@@ -80,8 +82,9 @@ class HttpClient : public IHttpClient {
     auto res = client_->Post(
         AddApiPrefix(path).data(), content_length,
         [&](size_t offset, size_t size, DataSink& sink) {
+          size = std::min<size_t>(size, kMaxChunkSize);
           auto [ok, data] = callback(offset, size);
-          sink.write(data.data(), data.size());
+          sink.write(data.data(), size);
           return ok;
         },
         mime.data());


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Bug fix

### What is the current behavior?

The `WritableRecord.Write` method always sends all data in one chunk

### What is the new behavior?

It splits data into chunks with size 1Mb.


### Does this PR introduce a breaking change?

No

### Other information:
